### PR TITLE
added custom role and role assignment

### DIFF
--- a/data-sources.tf
+++ b/data-sources.tf
@@ -1,1 +1,5 @@
 data "azuread_client_config" "current" {}
+
+data "azurerm_subscription" "primary" {}
+
+data "azurerm_client_config" "primary" {}


### PR DESCRIPTION
This enables Azure machine authentication to HashiCorp Vault using the Azure auth method.

- Added a new Custom Role Resource
- Custom Role conatins `Microsoft.Compute/virtualMachines/read` and `Microsoft.Compute/virtualMachineScaleSets/*/read` permissions
- Added new Service Principal resouce linked to Application Registration. This allows Custom Role Assignments
- Added Role Assignment for Custom Role to new Service Principal